### PR TITLE
Exit Gradle with error when a test fails in `junit` mode.

### DIFF
--- a/src/main/resources/clojuresque/tasks/test_junit.clj
+++ b/src/main/resources/clojuresque/tasks/test_junit.clj
@@ -24,11 +24,6 @@
 (defn add-counters [results counters]
   (merge-with + results counters))
 
-(defn check-result
-  [result]
-  (when (or (pos? (:fail result)) (pos? (:error result)))
-    (System/exit 1)))
-
 (defn escape-file-path 
   "Escapes the given file path so that it's safe for inclusion in a Clojure string literal."
   [directory file]
@@ -72,20 +67,16 @@
         ; test each namespace individually to allow per ns reporting of failures at the end
         (doseq [namespace namespaces]
           (test-namespace-with-junit-output namespace junit-output-dir))
-        (if (:test @results)
-          (do
-            (println "\nTotals:")
-            (report @results)
-            (println)
-            (if (successful? @results)
-              (do
-                (println "Success!!!")
-                true)
-              (do
-                (println "\n!!! There were test failures:")
-                ; Print results for each namespace which was unsuccessful
-                (doseq [[ns summary] @failed]
-                  (println ns ": " (:fail summary) "failures," (:error summary) "errors."))
-                (println)
-                false)))
-          true)))))
+        (when (:test @results)
+          (println "\nTotals:")
+          (report @results)
+          (println)
+          (if (successful? @results)
+            (println "Success!!!")
+            (do
+              (println "\n!!! There were test failures:")
+              ; Print results for each namespace which was unsuccessful
+              (doseq [[ns summary] @failed]
+                (println ns ": " (:fail summary) "failures," (:error summary) "errors."))
+              (println)
+              (System/exit 1))))))))


### PR DESCRIPTION
Hi!

Nebula (resp clojuresque) does not exit gradle with an error in `junit` mode when a test fails.

It seems that the value of `test-namespaces` in the `test-junit` workspace is not used; instead, when compared with similar functions in `test`, it should prematurally exit gradle.

also the function `check-result` is not used.

what do you think?
