### PR TITLE
Throw Exception if Errors and Failures is not 0

### DIFF
--- a/src/main/resources/clojuresque/tasks/test.clj
+++ b/src/main/resources/clojuresque/tasks/test.clj
@@ -7,7 +7,9 @@
 
 (defn check-result
   [result]
-  (and (zero? (:fail result)) (zero? (:error result))))
+  (let [{:keys [fail error]} result]
+    (if (not (zero? (reduce + [fail error])))
+        (throw (Exception. (clojure.string/join " " ["There are" fail "test failures and" error "errors."]))))))
 
 (defn test-namespaces
   [{:keys [source-files]}]


### PR DESCRIPTION
Builds with failing tests currently return exit code 0, allowing the build to proceed after failed tests.

Updated output looks like this:
```
Ran 1 tests containing 1 assertions.
1 failures, 0 errors.
Exception in thread "main" java.lang.Exception: There are 1 test failures and 0 errors., compiling:(null:198:44)
	at clojure.lang.Compiler.load(Compiler.java:7142)
	at clojure.lang.Compiler.load(Compiler.java:7095)
	at clojure.core$load_reader.invoke(core.clj:3766)
	at clojure.main$script_opt.invoke(main.clj:335)
	at clojure.main$main.doInvoke(main.clj:420)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.lang.Var.invoke(Var.java:379)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.Var.applyTo(Var.java:700)
	at clojure.main.main(main.java:37)
Caused by: java.lang.Exception: There are 1 test failures and 0 errors.
	at clojuresque.tasks.test$check_result.invoke(Unknown Source)
	at clojuresque.tasks.test$test_namespaces.invoke(Unknown Source)
	at clojuresque.tasks.test$eval141$main_task_driver__143.invoke(Unknown Source)
	at clojuresque.tasks.test$eval141$main__146.invoke(Unknown Source)
	at clojuresque.tasks.test$eval151.invoke(Unknown Source)
	at clojure.lang.Compiler.eval(Compiler.java:6703)
	at clojure.lang.Compiler.load(Compiler.java:7130)
	... 9 more
:clojureTest FAILED
```