### PR TITLE
Explicitly call `System/exit` after tests are run to ensure JVM exit

### DIFF
--- a/src/main/resources/clojuresque/tasks/test.clj
+++ b/src/main/resources/clojuresque/tasks/test.clj
@@ -42,12 +42,18 @@
 
 (deftask main
   [{:keys [junit tests] :as options}]
-  (try
-    (cond
-      junit       (test-junit/test-namespaces options)
-      (seq tests) (test-vars options)
-      :else       (test-namespaces options))
-  ;; Some stray non-daemon threads may cause the JVM to hang on exit.
-  ;; Call this after all tests have run to allow proper shutdown.
-  (finally
-    (shutdown-agents))))
+  (let [exit-code (atom 0)]
+    (try
+      (cond
+        junit (test-junit/test-namespaces options)
+        (seq tests) (test-vars options)
+        :else (test-namespaces options))
+      (catch Throwable _t
+        (reset! exit-code -1))
+      ;; Some stray non-daemon threads may cause the JVM to hang on exit.
+      ;; Call this after all tests have run to allow proper shutdown.
+      (finally
+        (shutdown-agents)
+        (.awaitTermination (clojure.lang.Agent/soloExecutor) 0 java.util.concurrent.TimeUnit/MILLISECONDS)
+        (.awaitTermination (clojure.lang.Agent/pooledExecutor) 0 java.util.concurrent.TimeUnit/MILLISECONDS)
+        (System/exit @exit-code)))))


### PR DESCRIPTION
The JVM recently started hanging after tests were run; even if successful. This change forces executors to terminate & explicitly calls `System/exit` to ensure the process exits.