### PR TITLE
Clojure Tasks: Cleanup Internal properties that should not be marked as Optional

### DIFF
--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
@@ -20,9 +20,7 @@ import kotka.gradle.utils.Delayed
 import clojure.lang.RT
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
@@ -52,7 +50,6 @@ class ClojureCompile extends ClojureSourceTask {
 
     @Internal
     @Delayed
-    @Optional
     def jvmOptions = {}
 
     @TaskAction

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureDoc.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureDoc.groovy
@@ -18,7 +18,6 @@ import kotka.gradle.utils.ConfigureUtil
 import kotka.gradle.utils.Delayed
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -36,7 +35,6 @@ class ClojureDoc extends ClojureSourceTask {
 
     @Delayed
     @Internal
-    @Optional
     def jvmOptions
 
     @Input

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRepl.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRepl.groovy
@@ -18,7 +18,6 @@ import nebula.plugin.clojuresque.Util
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -106,7 +105,6 @@ class ClojureRepl extends DefaultTask {
      */
     @Delayed
     @Internal
-    @Optional
     def jvmOptions
 
     /**

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRun.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRun.groovy
@@ -14,7 +14,6 @@ class ClojureRun extends ClojureSourceTask {
 
     @Delayed
     @Internal
-    @Optional
     def jvmOptions
 
     private String fn;

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
@@ -17,9 +17,7 @@ import kotka.gradle.utils.Delayed
 import nebula.plugin.clojuresque.Util
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
@@ -45,7 +43,6 @@ class ClojureTest extends ClojureSourceTask {
     def junitOutputDir = null
 
     @Internal
-    @Optional
     def tests = []
 
     @TaskAction


### PR DESCRIPTION
This is to allow compatibility with future versions of Gradle:

```

Welcome to Gradle 6.3-20200128230909+0000!

Starting a Gradle Daemon (subsequent builds will be faster)

> Configure project :
Inferred project: nebula-clojure-plugin, version: 9.4.0-dev.1.uncommitted+53f227f

> Task :validatePlugins FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':validatePlugins'.
> Plugin validation failed. See https://docs.gradle.org/6.3-20200128230909+0000/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'ClojureCompile': property 'jvmOptions' annotated with @Internal should not be also annotated with @Optional.
   > Warning: Type 'ClojureDoc': property 'jvmOptions' annotated with @Internal should not be also annotated with @Optional.
   > Warning: Type 'ClojureRepl': property 'jvmOptions' annotated with @Internal should not be also annotated with @Optional.
   > Warning: Type 'ClojureRun': property 'jvmOptions' annotated with @Internal should not be also annotated with @Optional.
   > Warning: Type 'ClojureTest': property 'tests' annotated with @Internal should not be also annotated with @Optional.

``` 