### PR TITLE
ClojureTest: classpath is marked as InputFiles

### DIFF
--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
@@ -20,6 +20,7 @@ import kotka.gradle.utils.Delayed
 import clojure.lang.RT
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.StopExecutionException
@@ -31,6 +32,7 @@ class ClojureCompile extends ClojureSourceTask {
     @Delayed
     def destinationDir
 
+    @InputFiles
     @Classpath
     @Delayed
     def classpath

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
@@ -17,6 +17,7 @@ import kotka.gradle.utils.Delayed
 import nebula.plugin.clojuresque.Util
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.StopExecutionException
@@ -27,6 +28,7 @@ class ClojureTest extends ClojureSourceTask {
     @Internal
     def outputDir
 
+    @InputFiles
     @Classpath
     @Delayed
     def classpath


### PR DESCRIPTION
Per docs in https://docs.gradle.org/current/userguide/more_about_tasks.html

```
Note: The @Classpath annotation was introduced in Gradle 3.2. To stay compatible with earlier Gradle versions, classpath properties should also be annotated with @InputFiles.
``` 