### PR TITLE
Add support for Toolchains

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -22,10 +22,14 @@ jobs:
     strategy:
       matrix:
         # test against latest update of some major Java version(s), as well as specific LTS version(s)
-        java: [ 8, 11 ]
+        java: [ 11, 13 ]
     name: Gradle Build without Publish
     steps:
       - uses: actions/checkout@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,11 @@ contacts {
 }
 
 dependencies {
-    implementation 'org.clojure:clojure:1.7.0'
+    implementation 'org.clojure:clojure:1.10.3'
     implementation ('de.kotka.gradle:gradle-utils:0.2.2') {
         exclude group: 'org.codehaus.groovy'
     }
-    implementation 'org.clojure:tools.namespace:0.2.11'
+    implementation 'org.clojure:tools.namespace:1.1.0'
     implementation 'us.bpsm:edn-java:0.4.3'
 
     testImplementation gradleTestKit()

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -3,6 +3,10 @@
 # This file is expected to be part of source control.
 de.kotka.gradle:gradle-utils:0.2.2
 de.kotka.groovy:zweig:0.4.0
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 us.bpsm:edn-java:0.4.3

--- a/gradle/dependency-locks/integTestCompileClasspath.lockfile
+++ b/gradle/dependency-locks/integTestCompileClasspath.lockfile
@@ -29,8 +29,12 @@ net.java.dev.jna:platform:3.4.0
 org.antlr:antlr-runtime:3.4
 org.apache.httpcomponents:httpclient:4.3.6
 org.apache.httpcomponents:httpcore:4.3.3
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 org.eclipse.jgit:org.eclipse.jgit:4.4.1.201607150455-r
 org.hamcrest:hamcrest-core:1.3
 org.slf4j:slf4j-api:1.7.2

--- a/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
@@ -30,8 +30,12 @@ net.java.dev.jna:platform:3.4.0
 org.antlr:antlr-runtime:3.4
 org.apache.httpcomponents:httpclient:4.3.6
 org.apache.httpcomponents:httpcore:4.3.3
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 org.eclipse.jgit:org.eclipse.jgit:4.4.1.201607150455-r
 org.hamcrest:hamcrest-core:1.3
 org.objenesis:objenesis:2.4

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -3,6 +3,10 @@
 # This file is expected to be part of source control.
 de.kotka.gradle:gradle-utils:0.2.2
 de.kotka.groovy:zweig:0.4.0
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 us.bpsm:edn-java:0.4.3

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -29,8 +29,12 @@ net.java.dev.jna:platform:3.4.0
 org.antlr:antlr-runtime:3.4
 org.apache.httpcomponents:httpclient:4.3.6
 org.apache.httpcomponents:httpcore:4.3.3
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 org.eclipse.jgit:org.eclipse.jgit:4.4.1.201607150455-r
 org.hamcrest:hamcrest-core:1.3
 org.slf4j:slf4j-api:1.7.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -30,8 +30,12 @@ net.java.dev.jna:platform:3.4.0
 org.antlr:antlr-runtime:3.4
 org.apache.httpcomponents:httpclient:4.3.6
 org.apache.httpcomponents:httpcore:4.3.3
-org.clojure:clojure:1.7.0
-org.clojure:tools.namespace:0.2.11
+org.clojure:clojure:1.10.3
+org.clojure:core.specs.alpha:0.2.56
+org.clojure:java.classpath:1.0.0
+org.clojure:spec.alpha:0.2.194
+org.clojure:tools.namespace:1.1.0
+org.clojure:tools.reader:1.3.4
 org.eclipse.jgit:org.eclipse.jgit:4.4.1.201607150455-r
 org.hamcrest:hamcrest-core:1.3
 org.objenesis:objenesis:2.4

--- a/src/main/groovy/nebula/plugin/clojuresque/ClojureBasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/ClojureBasePlugin.groovy
@@ -20,7 +20,6 @@ import nebula.plugin.clojuresque.tasks.ClojureUploadConvention
 import nebula.plugin.clojuresque.tasks.DefaultClojureSourceSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureCompile.groovy
@@ -27,7 +27,8 @@ import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 
-class ClojureCompile extends ClojureSourceTask {
+
+abstract class ClojureCompile extends ClojureSourceTask {
     @OutputDirectory
     @Delayed
     def destinationDir
@@ -112,6 +113,9 @@ class ClojureCompile extends ClojureSourceTask {
                 "(clojuresque.tasks.compile/main)",
                 Util.optionsToStream(options)
             ])
+            if(launcher.isPresent()) {
+                setExecutable(launcher.get().getExecutablePath().getAsFile().getAbsolutePath())
+            }
         }
 
         if (!getAotCompile()) {

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureDoc.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureDoc.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
-class ClojureDoc extends ClojureSourceTask {
+abstract class ClojureDoc extends ClojureSourceTask {
     @OutputDirectory
     @Delayed
     def destinationDir
@@ -91,6 +91,9 @@ class ClojureDoc extends ClojureSourceTask {
                 "(clojuresque.tasks.doc/main)",
                 Util.optionsToStream(options)
             ])
+            if(launcher.isPresent()) {
+                setExecutable(launcher.get().getExecutablePath().getAsFile().getAbsolutePath())
+            }
         }
 
         [

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRun.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureRun.groovy
@@ -6,7 +6,7 @@ import nebula.plugin.clojuresque.Util
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option;
 
-class ClojureRun extends ClojureSourceTask {
+abstract class ClojureRun extends ClojureSourceTask {
 
     @Classpath
     @Delayed
@@ -49,6 +49,9 @@ class ClojureRun extends ClojureSourceTask {
                 "(clojuresque.tasks.run/main)",
                 Util.optionsToStream(options)
             ])
+            if(launcher.isPresent()) {
+                setExecutable(launcher.get().getExecutablePath().getAsFile().getAbsolutePath())
+            }
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureSourceTask.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureSourceTask.groovy
@@ -14,11 +14,30 @@ package nebula.plugin.clojuresque.tasks
 
 import nebula.plugin.clojuresque.Util
 import nebula.plugin.utils.tasks.SourceDirectoryTask
-import org.gradle.api.tasks.Internal
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
 
-class ClojureSourceTask extends SourceDirectoryTask {
+import javax.inject.Inject
+
+abstract class ClojureSourceTask extends SourceDirectoryTask {
+    @Nested
+    @Optional
+    abstract Property<JavaLauncher> getLauncher()
+
+    @Inject
+    ClojureSourceTask() {
+        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).toolchain
+        JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class)
+        Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain)
+        launcher.convention(defaultLauncher)
+    }
+
     /* Duplicate the functionality of ClojureSourceSet. */
-
     ClojureSourceTask includeNamespace(String pattern) {
         include(Util.namespaceFile(pattern))
         return this

--- a/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/tasks/ClojureTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
-class ClojureTest extends ClojureSourceTask {
+abstract class ClojureTest extends ClojureSourceTask {
     @Delayed
     @Internal
     def outputDir
@@ -84,6 +84,9 @@ class ClojureTest extends ClojureSourceTask {
                 "(clojuresque.tasks.test/main)",
                 Util.optionsToStream(options)
             ])
+            if(launcher.isPresent()) {
+                setExecutable(launcher.get().getExecutablePath().getAsFile().getAbsolutePath())
+            }
         }
     }
 }

--- a/src/test/groovy/nebula/plugin/clojure/NoToolchainNebulaClojurePluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/clojure/NoToolchainNebulaClojurePluginIntegrationSpec.groovy
@@ -2,11 +2,12 @@ package nebula.plugin.clojure
 
 import nebula.test.IntegrationTestKitSpec
 
-class NebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
+class NoToolchainNebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
 
     def setup() {
         debug = true
     }
+
     private final APP_CLJ = '''\
             (ns test.nebula.app)
             
@@ -23,9 +24,9 @@ class NebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
             }
             
             repositories { mavenCentral() }
-    
+
             dependencies {
-                implementation 'org.clojure:clojure:1.8.0'
+                implementation 'org.clojure:clojure:1.10.3'
             }
             '''.stripIndent()
 
@@ -56,7 +57,7 @@ class NebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
             clojure.aotCompile = true
 
             dependencies {
-                implementation 'org.clojure:clojure:1.8.0'
+                implementation 'org.clojure:clojure:1.10.3'
             }
             '''.stripIndent()
 
@@ -88,11 +89,43 @@ class NebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
             clojure.warnOnReflection = true
 
             dependencies {
-                implementation 'org.clojure:clojure:1.8.0'
+                implementation 'org.clojure:clojure:1.10.3'
             }
             '''.stripIndent()
 
         settingsFile << 'rootProject.name="can-compile-clojure-warnOnReflection"'
+
+        def clojurefiles = new File(projectDir, 'src/main/clojure/test/nebula')
+        clojurefiles.mkdirs()
+        new File(clojurefiles, 'app.clj').text = APP_CLJ
+
+        when:
+        def result = runTasks('build')
+
+        then:
+        noExceptionThrown()
+
+        and:
+        new File(projectDir, "//build/classes/java/main/test/nebula/app.clj").exists()
+    }
+
+    def 'can compile clojure when source/target compatibility are set'() {
+        buildFile << '''\
+            plugins {
+                id 'nebula.clojure'
+            }
+            
+            repositories { mavenCentral() }
+
+            dependencies {
+                implementation 'org.clojure:clojure:1.10.3'
+            }
+            
+            sourceCompatibility = 1.8
+            targetCompatibility = 1.8
+            '''.stripIndent()
+
+        settingsFile << 'rootProject.name="can-compile-clojure"'
 
         def clojurefiles = new File(projectDir, 'src/main/clojure/test/nebula')
         clojurefiles.mkdirs()

--- a/src/test/groovy/nebula/plugin/clojure/ToolchainNebulaClojurePluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/clojure/ToolchainNebulaClojurePluginIntegrationSpec.groovy
@@ -1,0 +1,126 @@
+package nebula.plugin.clojure
+
+import nebula.test.IntegrationTestKitSpec
+
+class ToolchainNebulaClojurePluginIntegrationSpec extends IntegrationTestKitSpec {
+
+    private final APP_CLJ = '''\
+            (ns test.nebula.app)
+            
+            (defn hello
+              [name]
+              (println "hello" name))
+            '''.stripIndent()
+
+
+    def 'can compile clojure'() {
+        debug = true
+        buildFile << '''\
+            plugins {
+                id 'nebula.clojure'
+            }
+            
+            repositories { mavenCentral() }
+    
+            dependencies {
+                implementation 'org.clojure:clojure:1.10.3'
+            }
+            
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(8)
+                }
+            }
+            '''.stripIndent()
+
+        settingsFile << 'rootProject.name="can-compile-clojure"'
+
+        def clojurefiles = new File(projectDir, 'src/main/clojure/test/nebula')
+        clojurefiles.mkdirs()
+        new File(clojurefiles, 'app.clj').text = APP_CLJ
+
+        when:
+        def result = runTasks('build', '-i')
+
+        then:
+        noExceptionThrown()
+
+        and:
+        new File(projectDir, "//build/classes/java/main/test/nebula/app.clj").exists()
+    }
+
+    def 'can compile clojure with aotCompile'() {
+        buildFile << '''\
+            plugins {
+                id 'nebula.clojure'
+            }
+            
+            repositories { mavenCentral() }
+            
+            clojure.aotCompile = true
+
+            dependencies {
+                implementation 'org.clojure:clojure:1.10.3'
+            }
+            
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(8)
+                }
+            }
+            '''.stripIndent()
+
+        settingsFile << 'rootProject.name="can-compile-clojure-aotCompile"'
+
+        def clojurefiles = new File(projectDir, 'src/main/clojure/test/nebula')
+        clojurefiles.mkdirs()
+        new File(clojurefiles, 'app.clj').text = APP_CLJ
+
+
+        when:
+        def result = runTasks('build', '-i')
+
+        then:
+        noExceptionThrown()
+
+        and:
+        new File(projectDir, "//build/classes/java/main/test/nebula/app__init.class").exists()
+    }
+
+    def 'can compile clojure with warnOnReflection'() {
+        buildFile << '''\
+            plugins {
+                id 'nebula.clojure'
+            }
+            
+            repositories { mavenCentral() }
+            
+            clojure.warnOnReflection = true
+
+            dependencies {
+                implementation 'org.clojure:clojure:1.10.3'
+            }
+            
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(8)
+                }
+            }
+            '''.stripIndent()
+
+        settingsFile << 'rootProject.name="can-compile-clojure-warnOnReflection"'
+
+        def clojurefiles = new File(projectDir, 'src/main/clojure/test/nebula')
+        clojurefiles.mkdirs()
+        new File(clojurefiles, 'app.clj').text = APP_CLJ
+
+        when:
+        def result = runTasks('build')
+
+        then:
+        noExceptionThrown()
+
+        and:
+        new File(projectDir, "//build/classes/java/main/test/nebula/app.clj").exists()
+    }
+}


### PR DESCRIPTION
This is initial support for toolchains with nebula.clojure plugin

Because this plugin does not use a compile task, I'm adding the toolchain executable to the `javaexec` per https://docs.gradle.org/current/userguide/toolchains.html#sec:plugins

Also upgraded clojure to support modern versions of JDK

Here is an output where I asked for JDK 16 for the toolchain:

```
 Configure project :
Evaluating root project 'can-compile-clojure-aotCompile' using build file '/Users/rperezalcolea/Projects/github/nebula-plugins/nebula-clojure-plugin/build/nebulatest/nebula.plugin.clojure.ToolchainNebulaClojurePluginIntegrationSpec/can-compile-clojure-with-aotCompile/build.gradle'.
All projects evaluated.
Selected primary task 'build' from project :
Starting process 'command '/usr/libexec/java_home''. Working directory: /Users/rperezalcolea/Projects/github/nebula-plugins/nebula-clojure-plugin Command: /usr/libexec/java_home -V
Successfully started process 'command '/usr/libexec/java_home''
Java Toolchain auto-detection failed to find local MacOS system JVMs
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.252-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980142-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/8.0.252-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.252-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/14.0.1-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980242-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/14.0.1-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/14.0.1-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.10-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980302-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/11.0.10-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.10-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.11-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980385-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/11.0.11-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.11-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.6-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980471-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/11.0.6-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.6-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.265-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980557-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/8.0.265-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.265-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/16.0.1-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980641-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/16.0.1-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/16.0.1-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.7-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980693-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/11.0.7-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/11.0.7-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.265-amzn/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980784-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/8.0.265-amzn/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/8.0.265-amzn/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/13.0.2-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980865-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/13.0.2-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/13.0.2-zulu/bin/java''
Starting process 'command '/Users/rperezalcolea/.sdkman/candidates/java/16.0.0-zulu/bin/java''. Working directory: /var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/1624303980924-0 Command: /Users/rperezalcolea/.sdkman/candidates/java/16.0.0-zulu/bin/java -cp . JavaProbe
Successfully started process 'command '/Users/rperezalcolea/.sdkman/candidates/java/16.0.0-zulu/bin/java''
Tasks to be executed: [task ':compileClojure', task ':compileJava', task ':processResources', task ':classes', task ':jar', task ':assemble', task ':clojureTest', task ':compileTestJava', task ':processTestResources', task ':testClasses', task ':test', task ':check', task ':build']
Tasks that were excluded: []
:compileClojure (Thread[Execution worker for ':' Thread 11,5,main]) started.
``` 

It is important to note that this doesn't work with `source/target` compatibility 

```
Caused by: org.gradle.api.InvalidUserDataException: The new Java toolchain feature cannot be used at the project level in combination with source and/or target compatibility
	at org.gradle.api.plugins.JavaBasePlugin.checkToolchainAndCompatibilityUsage(JavaBasePlugin.java:346)
	at org.gradle.api.plugins.JavaBasePlugin.lambda$determineCompatibility$8(JavaBasePlugin.java:329)
	at org.gradle.util.GUtil.uncheckedCall(GUtil.java:454)
	at org.gradle.internal.extensibility.ConventionAwareHelper$2.doGetValue(ConventionAwareHelper.java:82)
	
```

I'll check with Gradle folks on that portion :) 