### PR TITLE
fix: plugin failed in windows environment

### DIFF
--- a/src/main/groovy/nebula/plugin/clojuresque/ClojureBasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/clojuresque/ClojureBasePlugin.groovy
@@ -146,7 +146,7 @@ class ClojureBasePlugin implements Plugin<Project> {
 
     private File findOutputDir(SourceSet set) {
         return set.output.classesDirs.files.find {
-            it.path.contains('clojure/main') || it.path.contains('java/main')
+            it.path.contains("clojure${File.separator}main") || it.path.contains("java${File.separator}main")
         }
     }
 }


### PR DESCRIPTION
- exception was 'Cannot query the value of task ':****:clojureTest' property 'outputDir' because it has no value available.

